### PR TITLE
Front: KPI Filter by Campaign ID

### DIFF
--- a/client/src/components/DocForm.jsx
+++ b/client/src/components/DocForm.jsx
@@ -100,7 +100,7 @@ export default function DocForm({ visible, closeModal, userData, setActiveScreen
                                         placeholder="Detalhes do Script.."
                                         value={details}
                                         onChange={(e) => setDetails(e.target.value)}
-                                        rows={3}
+                                        rows={6}
                                         className="w-full border-2 p-2 my-1 rounded-md resize-none text-lg outline-[#008181]"
                                     ></textarea>
                                 </div>

--- a/client/src/components/MultiSelect.jsx
+++ b/client/src/components/MultiSelect.jsx
@@ -1,0 +1,79 @@
+import { useState, useRef, useEffect } from 'react'
+
+export default function MultiSelectDropdown({
+    items,
+    onSelectionChange
+}) {
+    const [selectedItems, setSelectedItems] = useState([])
+    const [isVisibleOptions, setVisibleOptions] = useState(false)
+    const dropdowRef = useRef(null)
+
+    const toggleItem = (item) => {
+
+        const updateSelection = selectedItems.includes(item)
+            ? selectedItems.filter((item) => item !== item)
+            : [...selectedItems, item]
+
+        setSelectedItems(updateSelection)
+        onSelectionChange(updateSelection)
+    }
+
+    function toggleVisible() {
+        if (isVisibleOptions) {
+            setVisibleOptions(false)
+        } else {
+            setVisibleOptions(true)
+        }
+    }
+
+    useEffect(() => {
+        function observeOutsideClicks() {
+            if (dropdowRef.current && !dropdowRef.current.contains(event.target)) {
+                setVisibleOptions(false)
+                setSelectedItems([])
+                onSelectionChange([])
+            }
+        }
+
+        document.addEventListener('mousedown', observeOutsideClicks)
+
+        return () => {
+            document.removeEventListener('mousedown', observeOutsideClicks)
+        }
+    }, [])
+
+    function multiselectLabel(selectedItems) {
+        return selectedItems.length > 2
+            ? `${selectedItems.length} Selecionadas`
+            : selectedItems.join(', ')
+    }
+
+    const isItemSelected = (item) => selectedItems.includes(item)
+
+    return (
+        <div className="relative w-[180px]" ref={dropdowRef}>
+            <button
+                className="w-full py-2 px-3 border-2 rounded-md cursor-pointer text-left bg-white"
+                onClick={() => toggleVisible()}
+            >
+                {selectedItems.length > 0 ? multiselectLabel(selectedItems) : `Todas`}
+            </button>
+            <div className={isVisibleOptions === true ? `absolute z-10 mt-1 w-full bg-white border-2 rounded-md shadow-lg h-[200px] overflow-y-scroll` : `hidden`}>
+                {items.map((item) => (
+                    <label
+                        key={item}
+                        className="flex items-center p-2 cursor-pointer hover:bg-gray-100"
+                    >
+                        <input
+                            type="checkbox"
+                            checked={isItemSelected(item)}
+                            onChange={() => toggleItem(item)}
+                            className="mr-2"
+                        />
+                        {item}
+                    </label>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/client/src/views/modules/DocViewer.jsx
+++ b/client/src/views/modules/DocViewer.jsx
@@ -52,11 +52,12 @@ export default function DocViewer({
                     <textarea
                         value={document?.details}
                         className="bg-transparent w-full outline-none text-lg resize-none"
+                        rows={6}
                     ></textarea>
                 </div>
                 <h3 className="font-semibold text-xl mb-1">Script</h3>
                 <div
-                    className="border-2 border-slate-300 p-2 flex justify-center items-center w-[140px] rounded-md shadow-sm cursor-pointer"
+                    className="border-2 border-slate-300 p-2 flex justify-center items-center max-w-[300px] rounded-md shadow-sm cursor-pointer"
                 >
                     <img
                         src="/docs.svg"

--- a/client/src/views/modules/Docs.jsx
+++ b/client/src/views/modules/Docs.jsx
@@ -65,9 +65,9 @@ export default function Docs({
                                 docsData.map((document) => (
                                     <div 
                                         onClick={() => openViewer(document)}
-                                        className="border-2 rounded-md bg-white p-4 w-[300px] mx-2 text-left cursor-pointer shadow-sm transition hover:scale-[1.02] hover:border-[#008181]"
+                                        className="border-2 rounded-md bg-white p-4 w-[400px] mx-2 text-left cursor-pointer shadow-sm transition hover:scale-[1.02] hover:border-[#008181]"
                                     >
-                                        <h3 className="text-xl w-[160px] mt-2 font-semibold">{document.name}</h3>
+                                        <h3 className="text-xl w-auto mt-2 font-semibold">{document.name}</h3>
                                         <p className="w-[145px] text-ellipsis overflow-hidden whitespace-nowrap">{document.details}</p>
                                         <ul className="py-2 flex justify-start items-center">
                                             {

--- a/server/utils/smarticoEvents.js
+++ b/server/utils/smarticoEvents.js
@@ -1,0 +1,58 @@
+
+import axios from "axios"
+
+async function sendClientActionToSmartico(authKey, customerIdsInput, clientAction) {
+    // Sanitização e validação dos dados
+    clientAction = clientAction.trim();
+    const customerIds = customerIdsInput
+        .split('\n')
+        .map(id => id.trim())
+        .filter(id => /^\d{7,10}$/.test(id));
+
+    // Validação de quantidade de IDs
+    if (customerIds.length > 100000) {
+        return "Limite de 100.000 Customer IDs excedido.";
+    }
+
+    const payloads = customerIds.map(customerId => ({
+        eid: `event_${Math.random().toString(36).substr(2, 9)}`,
+        event_date: Math.floor(Date.now() / 1000) + 30,
+        ext_brand_id: "db9b8f68-5cfc-47af-a9fc-df32f46dc43c",
+        user_ext_id: customerId,
+        event_type: "client_action",
+        payload: {
+            client_action: clientAction
+        }
+    }));
+
+    if (payloads.length === 0) {
+        return "Nenhum Customer ID válido encontrado.";
+    }
+
+    const url = "https://apis3.smartico.ai/api/external/events/v2";
+
+    try {
+        const response = await axios.post(url, payloads, {
+            headers: {
+                Authorization: authKey,
+                "Content-Type": "application/json"
+            }
+        });
+
+        return response.status === 200
+            ? "Todos os payloads enviados com sucesso!"
+            : `Erro ao enviar payloads: HTTP ${response.status} - ${response.data}`;
+    } catch (error) {
+        return `Erro ao enviar payloads: ${error.message}`;
+    }
+}
+
+// Exemplo de uso
+(async () => {
+    const authKey = "3c62914d-58df-4e93-9082-d11f437a377c";
+    const customerIdsInput = "55562642"; // IDs de exemplo separados por nova linha
+    const clientAction = "PARTICIPOU_PALPITE";
+
+    const result = await sendClientActionToSmartico(authKey, customerIdsInput, clientAction);
+    console.log(result);
+})();


### PR DESCRIPTION
# Front: KPI Filter by Campaign ID
### O que foi feito
- Criado filtro de KPI por campaign ID, agora a "tabela" de KPIs não esta sendo utilizada, ao invés disso, o filtro e soma dos valores é feito direto na "tabela" de campanhas;
- Fix no front de descrição dos documentos, quando um documento tinha uma descrição muito grande, não dava para ler;
- Adicionado script smartico para disparo de actions (client_actions, js_markers)